### PR TITLE
Visual D 0.3.42 beta2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -742,3 +742,6 @@ unreleased Version 0.3.42
   * add integration into the Visual Studio Performance Wizard
   * added project template for console application built with DMD/LDC and x86/x64
   * bugzilla 14706: release configurations now enable optimizations and inlining by default
+  * mago is now the default debug engine for new projects
+  * demangle D/C++ symbols in disassembly with new tool dcxxfilt that supports both gcc
+    and MS C++ mangling.

--- a/CHANGES
+++ b/CHANGES
@@ -733,6 +733,12 @@ unreleased Version 0.3.42
     for build error with DustMite
   * update "Build Phobos Browse Info" and "Build local version of phobos" for dmd 2.067+
   * cv2pdb: 
-    - last version introduced crashes with DWARF conversions
-    - DWARF debug info now stripped from executable
+    - improved DWARF support:
+      - last version introduced crashes with DWARF conversions
+	  - now supports info in sections .debug_frame and .debug_loc for better display of locals
+      - DWARF debug info now stripped from executable
     - support for mspdb140.dll from VS2015
+	- now writes correct machine type to PDB for x64
+  * add integration into the Visual Studio Performance Wizard
+  * added project template for console application built with DMD/LDC and x86/x64
+  * bugzilla 14706: release configurations now enable optimizations and inlining by default

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ TLB2IDL_EXE = $(BINDIR)\tlb2idl.exe
 PIPEDMD_EXE = $(BINDIR)\pipedmd.exe
 LARGEADR_EXE= $(BINDIR)\largeadr.exe
 FILEMON_DLL = $(BINDIR)\filemonitor.dll
+DCXXFILT_EXE= $(BINDIR)\dcxxfilt.exe
 VSI2D_EXE   = $(BINDIR)\vsi2d.exe
 VSI_LIB     = $(BINDIR)\vsi.lib
 VISUALD     = $(BINDIR)\visuald.dll
@@ -157,6 +158,10 @@ cv2pdb:
 	cd ..\..\cv2pdb\trunk && devenv /Project "dviewhelper" /Build "Release|Win32" src\cv2pdb_vs12.sln
 	cd ..\..\cv2pdb\trunk && devenv /Project "dumplines"   /Build "Release|Win32" src\cv2pdb_vs12.sln
 
+dcxxfilt: $(DCXXFILT_EXE)
+$(DCXXFILT_EXE): tools\dcxxfilt.d
+	cd tools && set CONFIG=Release&& build_dcxxfilt
+	
 ##################################
 # create installer
 
@@ -164,7 +169,7 @@ install: all cpp2d_exe idl2d_exe
 	cd nsis && "$(NSIS)\makensis" /V1 visuald.nsi
 	"$(ZIP)" -j ..\downloads\visuald_pdb.zip bin\release\visuald.pdb bin\release\vdserver.pdb
 
-install_vs: prerequisites visuald_vs vdserver cv2pdb dparser vdextension mago install_only
+install_vs: prerequisites visuald_vs vdserver cv2pdb dparser vdextension mago dcxxfilt install_only
 
 install_only:
 	cd nsis && "$(NSIS)\makensis" /V1 visuald.nsi

--- a/VERSION
+++ b/VERSION
@@ -2,4 +2,4 @@
 #define VERSION_MINOR      3
 #define VERSION_REVISION   42
 #define VERSION_BETA       -beta
-#define VERSION_BUILD      1
+#define VERSION_BUILD      2

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -186,6 +186,7 @@ Section "Visual Studio package" SecPackage
   ${File} ..\bin\${CONFIG}\ vdserver.exe
   ${File} ..\bin\${CONFIG}\ pipedmd.exe
   ${File} ..\bin\${CONFIG}\ filemonitor.dll
+  ${File} ..\bin\${CONFIG}\ dcxxfilt.exe
   ${File} ..\ README.md
   ${File} ..\ LICENSE_1_0.txt
   ${File} ..\ CHANGES

--- a/tools/build_dcxxfilt.bat
+++ b/tools/build_dcxxfilt.bat
@@ -1,0 +1,26 @@
+@echo off
+rem unpack and configure binutils 2.25+
+rem don't use spaces in path names!
+
+setlocal
+if "%DMDINSTALLDIR%" == "" set DMDINSTALLDIR=m:\s\d\rainers
+if "%DMD%" == "" set DMD=%DMDINSTALLDIR%\windows\bin\dmd
+if "%BINUTILS%" == "" set BINUTILS=c:\s\cpp\cxxfilt
+
+if "%CONFIG%" == "" set CONFIG=Debug
+
+set OUTDIR=..\bin\%CONFIG%
+set LIBIBERTY=%BINUTILS%\libiberty
+
+%DMD% -c -m32mscoff -of%OUTDIR%\dcxxfilt.obj dcxxfilt.d || exit /B 1
+
+set SRC=
+set SRC=%SRC% %LIBIBERTY%\d-demangle.c
+set SRC=%SRC% %LIBIBERTY%\cp-demangle.c %LIBIBERTY%\cplus-dem.c 
+set SRC=%SRC% %LIBIBERTY%\xmalloc.c %LIBIBERTY%\xstrdup.c %LIBIBERTY%\xexit.c 
+set SRC=%SRC% %LIBIBERTY%\safe-ctype.c 
+set SRC=%SRC% %LIBIBERTY%\alloca.c
+
+set COPT=-I %BINUTILS% -I %BINUTILS%\include -I %BINUTILS%\binutils -DHAVE_CONFIG_H
+set LIB=%LIB%;%DMDINSTALLDIR%\lib32
+cl /Ox /Fe%OUTDIR%\dcxxfilt.exe /Fo%OUTDIR%\ %COPT% %SRC% %OUTDIR%\dcxxfilt.obj dbghelp.lib

--- a/tools/dcxxfilt.d
+++ b/tools/dcxxfilt.d
@@ -1,0 +1,144 @@
+/* Demangler for D/C++ - gcc and MS style mangling
+
+   Copyright (C) 2015 Free Software Foundation, Inc.
+   Written by Rainer Schuetze (r.sagitario@gmx.de)
+
+   This file is using part of GNU Binutils, inspired by cxxfilt
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or (at
+   your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING.  If not, write to the Free
+   Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA
+   02110-1301, USA.  */
+
+import core.demangle;
+import core.stdc.stdio;
+import core.stdc.stdlib;
+import core.stdc.string;
+
+extern(Windows) uint UnDecorateSymbolName(in char* DecoratedName, char* UnDecoratedName,
+                                          uint UndecoratedLength, uint Flags);
+extern(C) char* dlang_demangle(const char* mangled_name, uint flags);
+extern(C) char* cplus_demangle(const char* mangled_name, uint flags);
+
+enum DMGL_PARAMS  = (1 << 0); /* Include function args */
+enum DMGL_ANSI    = (1 << 1); /* Include const, volatile, etc */
+enum DMGL_VERBOSE = (1 << 3); /* Include implementation details.  */
+
+uint flags =  DMGL_PARAMS | DMGL_ANSI | DMGL_VERBOSE;
+char msvc_buffer[32768];
+
+char* msvc_demangle (char *mangled_name)
+{
+    if (UnDecorateSymbolName (mangled_name, msvc_buffer.ptr, msvc_buffer.length, 0) == 0)
+        return null;
+    return msvc_buffer.ptr;
+}
+
+char* d_demangle (char[] mangled)
+{
+    size_t pos = 0;
+    string s = decodeDmdString (mangled, pos);
+    char[] obuf;
+    if (pos == mangled.length)
+        obuf = demangle(s, msvc_buffer);
+    else
+        obuf = demangle(mangled, msvc_buffer);
+    if (obuf.ptr != msvc_buffer.ptr)
+        return null;
+    msvc_buffer[obuf.length] = 0;
+    return msvc_buffer.ptr;
+}
+
+void print_demangled (char[] mangled)
+{
+    char *result;
+	char[] initial = mangled;
+
+    /* . and $ are sometimes found at the start of function names
+    in assembler sources in order to distinguish them from other
+    names (eg register names).  So skip them here.  */
+    if (mangled[0] == '.' || mangled[0] == '$')
+        mangled = mangled[1..$];
+
+    if (mangled.length > 1 && mangled[0] == '_' && mangled[1] == 'D')
+        result = d_demangle (mangled);
+    else if (mangled.length > 0 && mangled[0] == '?')
+        result = msvc_demangle (mangled.ptr);
+    else
+        result = cplus_demangle (mangled.ptr, flags);
+
+    if (result == null)
+        printf ("%s", initial.ptr);
+    else
+    {
+        if (initial.ptr != mangled.ptr)
+            putchar (initial[0]);
+        printf ("%s", result);
+        if (result != msvc_buffer.ptr)
+            free (result);
+    }
+}
+
+bool isAlnum(int c)
+{
+	return c <= 'z' && c >= '0' && (c <= '9' || c >= 'a' || (c >= 'A' && c <= 'Z'));
+}
+
+int main (char[][] argv)
+{
+    int c;
+    const char *valid_symbols = "_$.?@";
+
+	if (argv.length > 1)
+	{
+		foreach(a; argv[1..$])
+		{
+			print_demangled(a);
+			putchar ('\n');
+		}
+		return 0;
+	}
+    for (;;)
+    {
+        static char mbuffer[32767];
+        uint i = 0;
+
+        c = getchar ();
+        /* Try to read a mangled name. Assume non-ascii characters to be part of the name */
+        while (c != EOF && (isAlnum (c) || strchr (valid_symbols, c) || c >= 128))
+        {
+            if (i >= mbuffer.length - 1)
+                break;
+            mbuffer[i++] = cast(char) c;
+            c = getchar ();
+        }
+
+        if (i > 0)
+        {
+            mbuffer[i] = 0;
+            print_demangled (mbuffer[0..i]);
+        }
+
+        if (c == EOF)
+            break;
+
+        /* Echo the whitespace characters so that the output looks
+        like the input, only with the mangled names demangled.  */
+        putchar (c);
+        if (c == '\n')
+            fflush (stdout);
+    }
+
+    fflush (stdout);
+    return 0;
+}

--- a/visuald/Templates/ProjectItems/ConsoleDMDLDC/ConsoleApp.visualdproj
+++ b/visuald/Templates/ProjectItems/ConsoleDMDLDC/ConsoleApp.visualdproj
@@ -34,34 +34,34 @@
 	<useInline>1</useInline>
     <outdir>$(ConfigurationName) $(PlatformName)</outdir> 
   </Config>
-  <Config name="Debug GDC" platform="Win32">
+  <Config name="Debug LDC" platform="Win32">
 	<isX86_64>0</isX86_64>
-	<compiler>1</compiler>
+	<compiler>2</compiler>
 	<runCv2pdb>1</runCv2pdb>
 	<symdebug>1</symdebug>
 	<release>0</release>
     <outdir>$(ConfigurationName) $(PlatformName)</outdir> 
   </Config>
-  <Config name="Release GDC" platform="Win32">
+  <Config name="Release LDC" platform="Win32">
 	<isX86_64>0</isX86_64>
-	<compiler>1</compiler>
+	<compiler>2</compiler>
 	<runCv2pdb>0</runCv2pdb>
 	<release>1</release>
 	<optimize>1</optimize>
 	<useInline>1</useInline>
     <outdir>$(ConfigurationName) $(PlatformName)</outdir> 
   </Config>
-  <Config name="Debug GDC" platform="x64">
+  <Config name="Debug LDC" platform="x64">
 	<isX86_64>1</isX86_64>
-	<compiler>1</compiler>
+	<compiler>2</compiler>
     <outdir>$(ConfigurationName) $(PlatformName)</outdir> 
 	<runCv2pdb>1</runCv2pdb>
 	<symdebug>1</symdebug>
 	<release>0</release>
   </Config>
-  <Config name="Release GDC" platform="x64">
+  <Config name="Release LDC" platform="x64">
 	<isX86_64>1</isX86_64>
-	<compiler>1</compiler>
+	<compiler>2</compiler>
 	<runCv2pdb>0</runCv2pdb>
 	<release>1</release>
 	<optimize>1</optimize>

--- a/visuald/Templates/ProjectItems/ConsoleDMDLDC/ConsoleApp.vstemplate
+++ b/visuald/Templates/ProjectItems/ConsoleDMDLDC/ConsoleApp.vstemplate
@@ -1,0 +1,18 @@
+<VSTemplate Version="2.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+  <TemplateData>
+    <Name>Console Application DMD/LDC x86/x64</Name>
+    <Description>A project for creating a command-line application with DMD/LDC for x86/x64</Description>
+    <Icon>__TemplateIcon.ico</Icon>
+    <ProjectType>D</ProjectType>
+    <SortOrder>50</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <CreateNewFolder>true</CreateNewFolder>
+    <DefaultName>ConsoleApplication</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+  </TemplateData>
+  <TemplateContent>
+    <Project File="ConsoleApp.visualdproj" ReplaceParameters="true">
+      <ProjectItem ReplaceParameters="true" OpenInEditor="true">main.d</ProjectItem>
+    </Project>
+  </TemplateContent>
+</VSTemplate>

--- a/visuald/Templates/ProjectItems/ConsoleDMDLDC/main.d
+++ b/visuald/Templates/ProjectItems/ConsoleDMDLDC/main.d
@@ -1,0 +1,7 @@
+import std.stdio;
+
+int main(string[] argv)
+{
+    writeln("Hello D-World!");
+    return 0;
+}

--- a/visuald/automation.d
+++ b/visuald/automation.d
@@ -1118,7 +1118,8 @@ class ExtProject : ExtProjectItem, dte.Project
 		/* [retval][out] */ dte.CodeModel *ppCodeModel)
 	{
 		mixin(LogCallMix);
-		return returnError(E_NOTIMPL);
+		*ppCodeModel = null;
+		return S_OK; // returnError(E_NOTIMPL);
 	}
 
 	override int Delete()

--- a/visuald/chiernode.d
+++ b/visuald/chiernode.d
@@ -15,6 +15,7 @@ import std.utf;
 
 import sdk.vsi.vsshell;
 import sdk.vsi.vsshell80;
+import sdk.vsi.vsshell110;
 import sdk.vsi.ivssccmanager2;
 
 import visuald.hierarchy;
@@ -252,6 +253,11 @@ public:
 			}
 			else
 				break;
+
+		case VSHPROPID_TargetPlatformIdentifier:
+			pvar.vt = VT_BSTR;
+			pvar.bstrVal = allocBSTR("Windows");
+			return S_OK;
 
 		default:
 			break;

--- a/visuald/comutil.d
+++ b/visuald/comutil.d
@@ -497,4 +497,3 @@ class ComTypeInfoHolder : DComObject, ITypeInfo
 		//return returnError(E_NOTIMPL);
 	}
 }
-

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -292,6 +292,8 @@ class ProjectOptions
 		runCv2pdb = dbg;
 		symdebug = dbg ? 1 : 0;
 		release = dbg ? 0 : 1;
+		optimize = release;
+		useInline = release;
 	}
 	void setX64(bool x64)
 	{

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -260,7 +260,7 @@ class ProjectOptions
 	string debugworkingdir;
 	bool debugattach;
 	string debugremote;
-	ubyte debugEngine; // 0: mixed, 1: mago
+	ubyte debugEngine; // 0: mixed, 1: mago, 2: native
 	bool debugStdOutToOutputWindow;
 	bool pauseAfterRunning;
 
@@ -281,6 +281,7 @@ class ProjectOptions
 		doXGeneration = true;
 		useStdLibPath = true;
 		cRuntime = CRuntime.StaticRelease;
+		debugEngine = 1;
 
 		filesToClean = "*.obj;*.cmd;*.build;*.json;*.dep";
 		setDebug(dbg);
@@ -2829,7 +2830,14 @@ class Config :	DisposingComObject,
 		GlobalOptions globOpt = Package.GetGlobalOptions();
 		string cmd = x64    ? mProjectOptions.compilerDirectories.DisasmCommand64 : 
 		             mscoff ? mProjectOptions.compilerDirectories.DisasmCommand32coff : mProjectOptions.compilerDirectories.DisasmCommand;
-		cmd = mProjectOptions.replaceEnvironment(cmd, this, objfile, outfile);
+		if(globOpt.demangleError)
+		{
+			string mangledfile = outfile ~ ".mangled";
+			cmd = mProjectOptions.replaceEnvironment(cmd, this, objfile, mangledfile);
+			cmd ~= "\nif errorlevel 0 \"" ~ Package.GetGlobalOptions().VisualDInstallDir ~ "dcxxfilt.exe\" < " ~ quoteFilename(mangledfile) ~ " > " ~ quoteFilename(outfile);
+		}
+		else
+			cmd = mProjectOptions.replaceEnvironment(cmd, this, objfile, outfile);
 		return cmd;
 	}
 

--- a/visuald/dpackage.d
+++ b/visuald/dpackage.d
@@ -108,7 +108,8 @@ const GUID    g_omLibraryManagerCLSID    = uuid("002a2de9-8bb6-484d-980b-7e4ad40
 const GUID    g_omLibraryCLSID           = uuid("002a2de9-8bb6-484d-980c-7e4ad4084715");
 const GUID    g_ProjectItemWizardCLSID   = uuid("002a2de9-8bb6-484d-980d-7e4ad4084715");
 
-const GUID    g_unmarshalCLSID           = uuid("002a2de9-8bb6-484d-980e-7e4ad4084715");
+const GUID    g_unmarshalEnumOutCLSID    = uuid("002a2de9-8bb6-484d-980e-7e4ad4084715");
+// const GUID g_unmarshalTargetInfoCLSID = uuid("002a2de9-8bb6-484d-980f-7e4ad4084715"); // defined in config.d
 
 const GUID    g_VisualDHelperCLSID       = uuid("002a2de9-8bb6-484d-aa10-7e4ad4084715");
 
@@ -171,9 +172,14 @@ HRESULT DllGetClassObject(CLSID* rclsid, IID* riid, LPVOID* ppv)
 		auto factory = newCom!ClassFactory;
 		return factory.QueryInterface(riid, ppv);
 	}
-	if(*rclsid == g_unmarshalCLSID)
+	if(*rclsid == g_unmarshalEnumOutCLSID)
 	{
 		DEnumOutFactory eof = newCom!DEnumOutFactory;
+		return eof.QueryInterface(riid, ppv);
+	}
+	static if(is(typeof(g_unmarshalTargetInfoCLSID))) if(*rclsid == g_unmarshalTargetInfoCLSID)
+	{
+		TargetInfoFactory eof = newCom!TargetInfoFactory;
 		return eof.QueryInterface(riid, ppv);
 	}
 	if(*rclsid == g_ProjectItemWizardCLSID)
@@ -215,11 +221,17 @@ class ClassFactory : DComObject, IClassFactory
 			Package pkg = newCom!Package;
 			return pkg.QueryInterface(riid, pvObject);
 		}
-		if(*riid == g_unmarshalCLSID)
+		if(*riid == g_unmarshalEnumOutCLSID)
 		{
 			assert(!UnkOuter);
 			DEnumOutputs eo = newCom!DEnumOutputs(null, 0);
 			return eo.QueryInterface(riid, pvObject);
+		}
+		static if(is(typeof(g_unmarshalTargetInfoCLSID))) if(*riid == g_unmarshalTargetInfoCLSID)
+		{
+			assert(!UnkOuter);
+			auto pti = newCom!ProfilerTargetInfo(null);
+			return pti.QueryInterface(riid, pvObject);
 		}
 		return S_FALSE;
 	}

--- a/visuald/logutil.d
+++ b/visuald/logutil.d
@@ -529,7 +529,7 @@ version(test) {
 
 	void logCall(...)
 	{
-		auto buffer = new char[17 + 1];
+		auto buffer = new char[32];
 		SysTime now = Clock.currTime();
 		uint tid = GetCurrentThreadId();
 		auto len = sprintf(buffer.ptr, "%02d:%02d:%02d - %04x - ",

--- a/visuald/propertypage.d
+++ b/visuald/propertypage.d
@@ -1808,7 +1808,7 @@ class ToolsProperty2Page : GlobalPropertyPage
 		AddControl("", mTimeBuilds    = new CheckBox(mCanvas, "Show build time"));
 		AddControl("", mStopSlnBuild  = new CheckBox(mCanvas, "Stop solution build on error"));
 		AddHorizontalLine();
-		AddControl("", mDemangleError = new CheckBox(mCanvas, "Demangle names in link errors"));
+		AddControl("", mDemangleError = new CheckBox(mCanvas, "Demangle names in link errors/disassembly"));
 		AddControl("", mOptlinkDeps   = new CheckBox(mCanvas, "Monitor linker dependencies"));
 		AddHorizontalLine();
 		//AddControl("Remove project item", mDeleteFiles = 

--- a/visuald/register.d
+++ b/visuald/register.d
@@ -406,7 +406,9 @@ HRESULT VSDllUnregisterServerInternal(in wchar* pszRegRoot, in bool useRanu)
 	foreach(guid; guids_propertyPages)
 		hr |= RegDeleteRecursive(keyRoot, registrationRoot ~ "\\CLSID\\"w ~ GUID2wstring(*guid));
 
-	hr |= RegDeleteRecursive(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(g_unmarshalCLSID));
+	hr |= RegDeleteRecursive(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(g_unmarshalEnumOutCLSID));
+	static if(is(typeof(g_unmarshalTargetInfoCLSID))) 
+		hr |= RegDeleteRecursive(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(g_unmarshalTargetInfoCLSID));
 
 	scope RegKey keyToolMenu = new RegKey(keyRoot, registrationRoot ~ "\\Menus"w);
 	keyToolMenu.Delete(packageGuid);
@@ -618,12 +620,17 @@ version(none){
 		RegDeleteRecursive(HKEY_CURRENT_USER, registrationRoot ~ "\\FontAndColors\\Cache"); // \\{A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0}");
 
 		// global registry keys for marshalled objects
-		scope RegKey keyMarshal1 = new RegKey(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(g_unmarshalCLSID) ~ "\\InprocServer32"w);
-		keyMarshal1.Set(null, dllPath);
-		keyMarshal1.Set("ThreadingModel"w, "Apartment"w);
-
-		scope RegKey keyMarshal2 = new RegKey(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(g_unmarshalCLSID) ~ "\\InprocHandler32"w);
-		keyMarshal2.Set(null, dllPath);
+		void registerMarshalObject(ref in GUID iid)
+		{
+			scope RegKey keyMarshal1 = new RegKey(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(iid) ~ "\\InprocServer32"w);
+			keyMarshal1.Set(null, dllPath);
+			keyMarshal1.Set("ThreadingModel"w, "Both"w);
+			scope RegKey keyMarshal2 = new RegKey(HKEY_CLASSES_ROOT, "CLSID\\"w ~ GUID2wstring(iid) ~ "\\InprocHandler32"w);
+			keyMarshal2.Set(null, dllPath);
+		}
+		registerMarshalObject(g_unmarshalEnumOutCLSID);
+		static if(is(typeof(g_unmarshalTargetInfoCLSID))) 
+			registerMarshalObject(g_unmarshalTargetInfoCLSID);
 
 		fixVS2012Shellx64Debugger(keyRoot, registrationRoot);
 

--- a/visuald/visuald.visualdproj
+++ b/visuald/visuald.visualdproj
@@ -515,11 +515,11 @@
    <File path="workaround.d" />
   </Folder>
   <Folder name="gc">
-   <File tool="None" path="..\..\..\rainers\druntime\src\gc\gcdump.d" />
-   <File tool="None" path="..\..\..\rainers\druntime\src\gc\gcx.d" />
-   <File tool="None" path="..\..\..\rainers\druntime\src\rt\lifetime.d" />
-   <File tool="None" path="..\..\..\rainers\druntime\src\rt\sections_win32.d" />
-   <File tool="None" path="..\vdc\semantic.d" />
+   <File path="..\..\..\rainers\druntime\src\gc\gcdump.d" tool="None" />
+   <File path="..\..\..\rainers\druntime\src\gc\gcx.d" tool="None" />
+   <File path="..\..\..\rainers\druntime\src\rt\lifetime.d" tool="None" />
+   <File path="..\..\..\rainers\druntime\src\rt\sections_win32.d" tool="None" />
+   <File path="..\vdc\semantic.d" tool="None" />
   </Folder>
   <Folder name="language">
    <File path="colorizer.d" />
@@ -552,7 +552,7 @@
    <File path="Resources\DSplashScreenIcon.bmp" />
    <File path="Resources\faninout.ico" />
    <File path="Resources\GroupByType.ico" />
-   <File tool="Custom" path="Resources\pkgcmd.ctc" customcmd="if &quot;%VS9SDKBIN%&quot; == &quot;&quot; set VS9SDKBIN=c:\l\vs9SDK\VisualStudioIntegration\Tools\Bin
+   <File path="Resources\pkgcmd.ctc" customcmd="if &quot;%VS9SDKBIN%&quot; == &quot;&quot; set VS9SDKBIN=c:\l\vs9SDK\VisualStudioIntegration\Tools\Bin
 set CTC=%VS9SDKBIN%\CTC.exe
 if not exist &quot;%CTC%&quot; goto no_CTC
 if not exist &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot; goto no_CTC
@@ -568,7 +568,7 @@ echo It is part of the VS2008 SDK and is needed to compile $(InputPath)
 if not exist $(InputDir)\$(InputName).cto exit 1
 echo $(InputDir)\$(InputName).cto exists, so it is assumed to be up to date.
 echo If the project rebuilt again and again with this message, touch $(InputDir)\$(InputName).cto to make it newer than $(InputDir)\$(InputName).ctc
-:reportError" outfile="$(InputDir)\$(InputName).cto" />
+:reportError" tool="Custom" outfile="$(InputDir)\$(InputName).cto" />
    <File path="Resources\refresh.ico" />
    <File path="Resources\RegExp.ico" />
    <File path="Resources\removetrace.ico" />
@@ -576,9 +576,9 @@ echo If the project rebuilt again and again with this message, touch $(InputDir)
    <File path="Resources\SearchFile.ico" />
    <File path="Resources\SearchSymbol.ico" />
    <File path="Resources\settrace.ico" />
-   <File tool="Custom" path="visuald.rc" dependencies="resources\pkgcmd.cto;resources\daboutlogo.ico;..\version;resources\dimagelist.bmp" customcmd="call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+   <File path="visuald.rc" customcmd="call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 rem if errorlevel 1 goto reportError
-rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" outfile="$(OutDir)\visuald.res" linkoutput="true" />
+rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" tool="Custom" dependencies="resources\pkgcmd.cto;resources\daboutlogo.ico;..\version;resources\dimagelist.bmp" linkoutput="true" outfile="$(OutDir)\visuald.res" />
    <File path="Resources\WholeWord.ico" />
   </Folder>
   <Folder name="Templates">
@@ -596,36 +596,36 @@ rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" outfile="$(OutDir)\visuald
     <File path="Templates\CodeSnippets\SnippetsIndex.xml" />
    </Folder>
    <Folder name="Items">
-    <File tool="None" path="Templates\Items\empty.d" />
-    <File tool="None" path="Templates\Items\hello.d" />
+    <File path="Templates\Items\empty.d" tool="None" />
+    <File path="Templates\Items\hello.d" tool="None" />
     <File path="Templates\Items\items.vsdir" />
    </Folder>
    <Folder name="ProjectItems">
     <Folder name="ConsoleApp">
      <File path="Templates\ProjectItems\ConsoleApp\ConsoleApp.visualdproj" />
      <File path="Templates\ProjectItems\ConsoleApp\ConsoleApp.vstemplate" />
-     <File tool="None" path="Templates\ProjectItems\ConsoleApp\main.d" />
+     <File path="Templates\ProjectItems\ConsoleApp\main.d" tool="None" />
     </Folder>
     <Folder name="ConsoleDMDGDC">
      <File path="Templates\ProjectItems\ConsoleDMDGDC\ConsoleApp.visualdproj" />
      <File path="Templates\ProjectItems\ConsoleDMDGDC\ConsoleApp.vstemplate" />
-     <File tool="None" path="Templates\ProjectItems\ConsoleDMDGDC\main.d" />
+     <File path="Templates\ProjectItems\ConsoleDMDGDC\main.d" tool="None" />
     </Folder>
     <Folder name="DynamicLib">
-     <File tool="None" path="Templates\ProjectItems\DynamicLib\dll.def" />
-     <File tool="None" path="Templates\ProjectItems\DynamicLib\dllmain.d" />
+     <File path="Templates\ProjectItems\DynamicLib\dll.def" tool="None" />
+     <File path="Templates\ProjectItems\DynamicLib\dllmain.d" tool="None" />
      <File path="Templates\ProjectItems\DynamicLib\DynamicLib.visualdproj" />
      <File path="Templates\ProjectItems\DynamicLib\DynamicLib.vstemplate" />
     </Folder>
     <Folder name="StaticLib">
-     <File tool="None" path="Templates\ProjectItems\StaticLib\lib.d" />
+     <File path="Templates\ProjectItems\StaticLib\lib.d" tool="None" />
      <File path="Templates\ProjectItems\StaticLib\StaticLib.visualdproj" />
      <File path="Templates\ProjectItems\StaticLib\StaticLib.vstemplate" />
     </Folder>
     <Folder name="WindowsApp">
      <File path="Templates\ProjectItems\WindowsApp\WindowsApp.visualdproj" />
      <File path="Templates\ProjectItems\WindowsApp\WindowsApp.vstemplate" />
-     <File tool="None" path="Templates\ProjectItems\WindowsApp\winmain.d" />
+     <File path="Templates\ProjectItems\WindowsApp\winmain.d" tool="None" />
     </Folder>
    </Folder>
    <Folder name="Projects">


### PR DESCRIPTION
  * add integration into the Visual Studio Performance Wizard
  * added project template for console application built with DMD/LDC and x86/x64
  * bugzilla 14706: release configurations now enable optimizations and inlining by default
  * mago is now the default debug engine for new projects
  * demangle D/C++ symbols in disassembly with new tool dcxxfilt that supports both gcc
    and MS C++ mangling.
