### PR TITLE
Visual D 0.3.43 beta2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -765,7 +765,7 @@ unreleased Version 0.3.43
   * replaced ancient pkgcmd.ctc with pkgcmd.vsct that's buildable with newer VS SDKs
   * added icons to some commands
   * renamed command "Add Folder" in project folder context menu to "Add Filter"
-  * added command "Add Package" to project folder context menu
+  * added command "Add Folder" to project folder context menu that actually creates the folder on disk
   * renaming a module in the project tree now reopens it at the previous caret location
   * renaming a package in the project tree also renames the folder on disk if it is still empty
   * debug info: added option "suitable for selected debug engine"
@@ -773,7 +773,7 @@ unreleased Version 0.3.43
   * LDC: recent versions build object files into intermediate folder, wrong names passed to linker
     with "separate compile and link"
   * moved defaults for resource includes and dmd executable paths from installation to extension init
-  * fixed spurious "not implemented" error in error list
+  * fixed spurious "not implemented" error in error list of VS 2015
   * fix dark theme detection in VS 2015
   * better semantic/colorizer support for versions LDC,CRuntime_Microsoft,CRuntime_DigitalMars and MinGW
   * tweaked default path and library settings for DMD and LDC
@@ -783,3 +783,8 @@ unreleased Version 0.3.43
     - scale some controls vertically if there is space
     - added browse buttons to path settings
   * search pane did not save its last state, only when switching between file and symbol search
+  * fixed calling linker to build with VC runtime of VS2015: legacy_stdio_definitions.lib missing
+  * bugzilla 12021: C++ projects (and others probably, too) might not load correctly in a solution
+    that also contains a Visual D project
+  * VS2015 linker updates logs and telemetry data files, confusing tracked linker dependencies. 
+    Now ignoring files that are both read and written.

--- a/TODO
+++ b/TODO
@@ -40,7 +40,7 @@ Project:
 - custom command: quotes in dependencies not supported
 - custom command: writes build batch to project folder
 - custom command: no output given => creates ".build.cmd"
-- single file commands: track dependencies
+- single file commands: track dependencies, also outputs
 - single file commands: multiple outputs
 
 - VS2013: property pages don't follow resize

--- a/VERSION
+++ b/VERSION
@@ -2,4 +2,4 @@
 #define VERSION_MINOR      3
 #define VERSION_REVISION   43
 #define VERSION_BETA       -beta
-#define VERSION_BUILD      1
+#define VERSION_BUILD      2

--- a/nsis/visuald.nsi
+++ b/nsis/visuald.nsi
@@ -230,6 +230,11 @@ Section "Visual Studio package" SecPackage
   ${File} ..\visuald\Templates\ProjectItems\ConsoleDMDGDC\ ConsoleApp.vstemplate
   ${File} ..\visuald\Templates\ProjectItems\ConsoleDMDGDC\ ConsoleApp.visualdproj
 
+  ${SetOutPath} "$INSTDIR\Templates\ProjectItems\ConsoleDMDLDC"
+  ${File} ..\visuald\Templates\ProjectItems\ConsoleDMDLDC\ main.d
+  ${File} ..\visuald\Templates\ProjectItems\ConsoleDMDLDC\ ConsoleApp.vstemplate
+  ${File} ..\visuald\Templates\ProjectItems\ConsoleDMDLDC\ ConsoleApp.visualdproj
+
   ${SetOutPath} "$INSTDIR\Templates\ProjectItems\WindowsApp"
   ${File} ..\visuald\Templates\ProjectItems\WindowsApp\ winmain.d
   ${File} ..\visuald\Templates\ProjectItems\WindowsApp\ WindowsApp.vstemplate

--- a/stdext/stdext.visualdproj
+++ b/stdext/stdext.visualdproj
@@ -117,7 +117,7 @@
   <vtls>0</vtls>
   <vgc>0</vgc>
   <symdebug>0</symdebug>
-  <optimize>0</optimize>
+  <optimize>1</optimize>
   <cpu>0</cpu>
   <isX86_64>0</isX86_64>
   <isLinux>0</isLinux>
@@ -136,7 +136,7 @@
   <noboundscheck>0</noboundscheck>
   <useSwitchError>0</useSwitchError>
   <useUnitTests>0</useUnitTests>
-  <useInline>0</useInline>
+  <useInline>1</useInline>
   <release>1</release>
   <preservePaths>0</preservePaths>
   <warnings>0</warnings>

--- a/visuald/Templates/Projects/DTemplates.vsdir
+++ b/visuald/Templates/Projects/DTemplates.vsdir
@@ -1,5 +1,6 @@
 ..\ProjectItems\ConsoleApp\ConsoleApp.vstemplate|{002A2DE9-8BB6-484D-987F-7E4AD4084715}|Console Application|30|A project for creating a command-line application|0|#1000|0|ConsoleApp
 ..\ProjectItems\ConsoleDMDGDC\ConsoleApp.vstemplate|{002A2DE9-8BB6-484D-987F-7E4AD4084715}|Console Application DMD/GDC|30|A project for creating a command-line application with DMD/GDC for x86/x64|0|#1000|0|ConsoleApp
+..\ProjectItems\ConsoleDMDLDC\ConsoleApp.vstemplate|{002A2DE9-8BB6-484D-987F-7E4AD4084715}|Console Application DMD/LDC|30|A project for creating a command-line application with DMD/GDC for x86/x64|0|#1000|0|ConsoleApp
 ..\ProjectItems\WindowsApp\WindowsApp.vstemplate|{002A2DE9-8BB6-484D-987F-7E4AD4084715}|Windows Application|30|A project for creating a Windows application|0|#1000|0|WindowsApp
 ..\ProjectItems\DynamicLib\DynamicLib.vstemplate|{002A2DE9-8BB6-484D-987F-7E4AD4084715}|Dynamic Library (DLL)|30|A project for creating a dynamic library|0|#1000|0|DynamicLib
 ..\ProjectItems\StaticLib\StaticLib.vstemplate|{002A2DE9-8BB6-484D-987F-7E4AD4084715}|Static Library|30|A project for creating a static library|0|#1000|0|StaticLib

--- a/visuald/chiernode.d
+++ b/visuald/chiernode.d
@@ -83,7 +83,7 @@ class CHierNode : DisposingDispatchObject
 	
 	override void Dispose()
 	{
-		m_extNode = release(m_extNode);
+		//m_extNode = release(m_extNode);
 	}
 
 	static void setContainerIsSorted(bool sort)
@@ -247,7 +247,7 @@ public:
 			{
 				pvar.vt = VT_DISPATCH;
 				if(!m_extNode)
-					m_extNode = addref(newCom!ExtProjectItem(null, null, this));
+					m_extNode = /*addref*/(newCom!ExtProjectItem(null, null, this));
 				pvar.pdispVal = addref(m_extNode);
 				return S_OK;
 			}

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -918,6 +918,10 @@ class ProjectOptions
 		string[] libs = tokenizeArgs(libfiles);
 		libs ~= "user32.lib";
 		libs ~= "kernel32.lib";
+		if(useMSVCRT())
+			if(std.file.exists(Package.GetGlobalOptions().VCInstallDir ~ "lib\\legacy_stdio_definitions.lib"))
+				libs ~= "legacy_stdio_definitions.lib";
+
 		cmd ~= plusList(lnkfiles ~ libs, ".lib", plus);
 		string[] lpaths = tokenizeArgs(libpaths);
 		if(useStdLibPath)

--- a/visuald/dproject.d
+++ b/visuald/dproject.d
@@ -243,7 +243,7 @@ class Project : CVsHierarchy,
 	override void Dispose()
 	{
 		mConfigProvider = release(mConfigProvider);
-		mExtProject = release(mExtProject);
+		//mExtProject = release(mExtProject);
 		super.Dispose();
 	}
 
@@ -700,7 +700,7 @@ class Project : CVsHierarchy,
 				case VSHPROPID_ExtObject:
 					var.vt = VT_DISPATCH;
 					if(!mExtProject)
-						mExtProject = addref(newCom!ExtProject(this));
+						mExtProject = /*addref*/(newCom!ExtProject(this));
 					var.pdispVal = addref(mExtProject);
 					return S_OK;
 

--- a/visuald/visuald.visualdproj
+++ b/visuald/visuald.visualdproj
@@ -33,14 +33,14 @@
   <useArrayBounds>0</useArrayBounds>
   <noboundscheck>0</noboundscheck>
   <useSwitchError>0</useSwitchError>
-  <useUnitTests>1</useUnitTests>
+  <useUnitTests>0</useUnitTests>
   <useInline>0</useInline>
   <release>0</release>
   <preservePaths>0</preservePaths>
   <warnings>0</warnings>
   <infowarnings>1</infowarnings>
   <checkProperty>0</checkProperty>
-  <genStackFrame>1</genStackFrame>
+  <genStackFrame>0</genStackFrame>
   <pic>0</pic>
   <cov>0</cov>
   <nofloat>0</nofloat>
@@ -515,11 +515,11 @@
    <File path="workaround.d" />
   </Folder>
   <Folder name="gc">
-   <File path="..\..\..\rainers\druntime\src\gc\gcdump.d" tool="None" />
-   <File path="..\..\..\rainers\druntime\src\gc\gcx.d" tool="None" />
-   <File path="..\..\..\rainers\druntime\src\rt\lifetime.d" tool="None" />
-   <File path="..\..\..\rainers\druntime\src\rt\sections_win32.d" tool="None" />
-   <File path="..\vdc\semantic.d" tool="None" />
+   <File tool="None" path="..\..\..\rainers\druntime\src\gc\gcdump.d" />
+   <File tool="None" path="..\..\..\rainers\druntime\src\gc\gcx.d" />
+   <File tool="None" path="..\..\..\rainers\druntime\src\rt\lifetime.d" />
+   <File tool="None" path="..\..\..\rainers\druntime\src\rt\sections_win32.d" />
+   <File tool="None" path="..\vdc\semantic.d" />
   </Folder>
   <Folder name="language">
    <File path="colorizer.d" />
@@ -552,7 +552,7 @@
    <File path="Resources\DSplashScreenIcon.bmp" />
    <File path="Resources\faninout.ico" />
    <File path="Resources\GroupByType.ico" />
-   <File path="Resources\pkgcmd.vsct" customcmd="set VSSDKInstall=%VSSDK140Install%
+   <File tool="Custom" path="Resources\pkgcmd.vsct" customcmd="set VSSDKInstall=%VSSDK140Install%
 if &quot;%VSSDKInstall%&quot; == &quot;&quot; set VSSDKInstall=%VSSDK120Install%
 if &quot;%VSSDKInstall%&quot; == &quot;&quot; set VSSDKInstall=%VSSDK110Install%
 if &quot;%VSSDKInstall%&quot; == &quot;&quot; set VSSDKInstall=%VSSDK100Install%
@@ -566,7 +566,7 @@ goto reportError
 :no_VSCT
 echo Warning: VSCT.exe not found as %VSCT%
 echo It is part of the VS2010-VS2013 SDK and is needed to compile $(InputPath)
-:reportError" tool="Custom" outfile="$(InputDir)\$(InputName).cto" />
+:reportError" outfile="$(InputDir)\$(InputName).cto" />
    <File path="Resources\refresh.ico" />
    <File path="Resources\RegExp.ico" />
    <File path="Resources\removetrace.ico" />
@@ -574,9 +574,9 @@ echo It is part of the VS2010-VS2013 SDK and is needed to compile $(InputPath)
    <File path="Resources\SearchFile.ico" />
    <File path="Resources\SearchSymbol.ico" />
    <File path="Resources\settrace.ico" />
-   <File path="visuald.rc" customcmd="call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
+   <File tool="Custom" path="visuald.rc" dependencies="resources\pkgcmd.cto;resources\daboutlogo.ico;..\version;resources\dimagelist.bmp" customcmd="call &quot;$(VSINSTALLDIR)\Common7\Tools\vsvars32.bat&quot;
 rem if errorlevel 1 goto reportError
-rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" tool="Custom" dependencies="resources\pkgcmd.cto;resources\daboutlogo.ico;..\version;resources\dimagelist.bmp" linkoutput="true" outfile="$(OutDir)\visuald.res" />
+rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" outfile="$(OutDir)\visuald.res" linkoutput="true" />
    <File path="Resources\WholeWord.ico" />
   </Folder>
   <Folder name="Templates">
@@ -594,36 +594,36 @@ rc /fo&quot;$(OutDir)\visuald.res&quot; $(InputPath)" tool="Custom" dependencies
     <File path="Templates\CodeSnippets\SnippetsIndex.xml" />
    </Folder>
    <Folder name="Items">
-    <File path="Templates\Items\empty.d" tool="None" />
-    <File path="Templates\Items\hello.d" tool="None" />
+    <File tool="None" path="Templates\Items\empty.d" />
+    <File tool="None" path="Templates\Items\hello.d" />
     <File path="Templates\Items\items.vsdir" />
    </Folder>
    <Folder name="ProjectItems">
     <Folder name="ConsoleApp">
      <File path="Templates\ProjectItems\ConsoleApp\ConsoleApp.visualdproj" />
      <File path="Templates\ProjectItems\ConsoleApp\ConsoleApp.vstemplate" />
-     <File path="Templates\ProjectItems\ConsoleApp\main.d" tool="None" />
+     <File tool="None" path="Templates\ProjectItems\ConsoleApp\main.d" />
     </Folder>
     <Folder name="ConsoleDMDGDC">
      <File path="Templates\ProjectItems\ConsoleDMDGDC\ConsoleApp.visualdproj" />
      <File path="Templates\ProjectItems\ConsoleDMDGDC\ConsoleApp.vstemplate" />
-     <File path="Templates\ProjectItems\ConsoleDMDGDC\main.d" tool="None" />
+     <File tool="None" path="Templates\ProjectItems\ConsoleDMDGDC\main.d" />
     </Folder>
     <Folder name="DynamicLib">
-     <File path="Templates\ProjectItems\DynamicLib\dll.def" tool="None" />
-     <File path="Templates\ProjectItems\DynamicLib\dllmain.d" tool="None" />
+     <File tool="None" path="Templates\ProjectItems\DynamicLib\dll.def" />
+     <File tool="None" path="Templates\ProjectItems\DynamicLib\dllmain.d" />
      <File path="Templates\ProjectItems\DynamicLib\DynamicLib.visualdproj" />
      <File path="Templates\ProjectItems\DynamicLib\DynamicLib.vstemplate" />
     </Folder>
     <Folder name="StaticLib">
-     <File path="Templates\ProjectItems\StaticLib\lib.d" tool="None" />
+     <File tool="None" path="Templates\ProjectItems\StaticLib\lib.d" />
      <File path="Templates\ProjectItems\StaticLib\StaticLib.visualdproj" />
      <File path="Templates\ProjectItems\StaticLib\StaticLib.vstemplate" />
     </Folder>
     <Folder name="WindowsApp">
      <File path="Templates\ProjectItems\WindowsApp\WindowsApp.visualdproj" />
      <File path="Templates\ProjectItems\WindowsApp\WindowsApp.vstemplate" />
-     <File path="Templates\ProjectItems\WindowsApp\winmain.d" tool="None" />
+     <File tool="None" path="Templates\ProjectItems\WindowsApp\winmain.d" />
     </Folder>
    </Folder>
    <Folder name="Projects">


### PR DESCRIPTION
  * fixed calling linker to build with VC runtime of VS2015: legacy_stdio_definitions.lib missing
  * bugzilla 12021: C++ projects (and others probably, too) might not load correctly in a solution
    that also contains a Visual D project
  * VS2015 linker updates logs and telemetry data files, confusing tracked linker dependencies. 
    Now ignoring files that are both read and written.
