### PR TITLE
Visual D 0.3.43

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -755,41 +755,44 @@ Version history
 
 2015-11-28 Version 0.3.43
 
-  * dustmite: pattern passed to "find" must always use quotes
-  * VS2015: new install adds $(VCInstallDir)\bin to exectuable paths to allow cv2pdb to create PDB files
-  * VS2015: added detection for Universal CRT in Win10 SDK, new macro replacements $(UCRTSdkDir) and 
-    $(UCRTVersion) allow adding library search path to find libucrt.lib
-  * New item: the module name no longer has a preceding '.' when guessing a package name
-  * when renaming a module in the project, the editor is reopened at the previous caret position if it was
-    opened before
-  * replaced ancient pkgcmd.ctc with pkgcmd.vsct that's buildable with newer VS SDKs
-  * added icons to some commands
-  * renamed command "Add Folder" in project folder context menu to "Add Filter"
-  * added command "Add Folder" to project folder context menu that actually creates the folder on disk
-  * renaming a module in the project tree now reopens it at the previous caret location
-  * renaming a package in the project tree also renames the folder on disk if it is still empty
-  * debug info: added option "suitable for selected debug engine"
-  * the original semantic analysis engine is no longer installed, always using dparser now
-  * LDC: recent versions build object files into intermediate folder, wrong names passed to linker
-    with "separate compile and link"
-  * moved defaults for resource includes and dmd executable paths from installation to extension init
-  * fixed spurious "not implemented" error in error list of VS 2015
-  * fix dark theme detection in VS 2015
-  * better semantic/colorizer support for versions LDC,CRuntime_Microsoft,CRuntime_DigitalMars and MinGW
-  * tweaked default path and library settings for DMD and LDC
+  * installation
+    - new install adds $(VCInstallDir)\bin to exectuable paths to allow cv2pdb to create PDB files
+    - moved defaults for resource includes and dmd executable paths from installation to extension init
+    - tweaked default path and library settings for DMD and LDC
+  * improved VS2015 support
+    - added detection for Universal CRT in Win10 SDK, new macro replacements $(UCRTSdkDir) and 
+      $(UCRTVersion) allow adding library search path to find libucrt.lib
+    - fixed spurious "not implemented" error in error list of VS 2015
+    - fix dark theme detection in VS 2015
+    - fixed calling linker to build with VC runtime of VS2015: legacy_stdio_definitions.lib missing
+    - VS2015 linker updates logs and telemetry data files, confusing tracked linker dependencies. 
+      Now ignoring files that are both read and written.
+  * project management
+    - New item: the module name no longer has a preceding '.' when guessing a package name
+    - renamed command "Add Folder" in project folder context menu to "Add Filter"
+    - added command "Add Folder" to project folder context menu that actually creates the folder on disk
+    - renaming a module in the project tree now reopens it at the previous caret location
+    - renaming a package in the project tree also renames the folder on disk if it is still empty
+    - bugzilla 12021: C++ projects (and others probably, too) might not load correctly in a solution
+      that also contains a Visual D project
+  * build system
+    - debug info: added option "suitable for selected debug engine"
+    - LDC: recent versions build object files into intermediate folder, wrong names passed to linker
+      with "separate compile and link"
+    - debug option: allow none of -debug and -release to be specified (and fix LDC never to receive 
+      the -d-debug option)
+    - additional options: now replacing newline with space when adding to the command line
+    - compiling file for syntax check with LDC passed wrong command line option
+    - pass VSINSTALLDIR in the environment to avoid autodetection by LDC
+  * language service
+    - the original semantic analysis engine is no longer installed, always using dparser now
+    - better semantic/colorizer support for versions LDC,CRuntime_Microsoft,CRuntime_DigitalMars and MinGW
+    - bugzilla 15345: syntax highlighting wrong if asm followed by function attributes
   * configuration dialogs:
     - fixed small fonts in VS2015
     - better work with resizeable windows
     - scale some controls vertically if there is space
     - added browse buttons to path settings
-  * search pane did not save its last state, only when switching between file and symbol search
-  * fixed calling linker to build with VC runtime of VS2015: legacy_stdio_definitions.lib missing
-  * bugzilla 12021: C++ projects (and others probably, too) might not load correctly in a solution
-    that also contains a Visual D project
-  * VS2015 linker updates logs and telemetry data files, confusing tracked linker dependencies. 
-    Now ignoring files that are both read and written.
-  * debug option: allow none of -debug and -release to be specified (and fix LDC never to receive 
-    the -d-debug option)
   * some improvements to the C++ to D conversion wizard:
     - don't stop conversion after an unmatched } (this also caused other messages to not be displayed)
     - added support for sizeof without parenthesis
@@ -797,7 +800,8 @@ Version history
     - allow virtual destructors
     - skip throw function specification
     - fix order of identifiers if "#define A B" is converted to an alias
-  * additional options: now replacing newline with space when adding to the command line
-  * compiling file for syntax check with LDC passed wrong command line option
-  * pass VSINSTALLDIR in the environment to avoid autodetection by LDC
-  * bugzilla 15345: syntax highlighting wrng if asm followed by function attributes
+  * miscellaneous
+    - replaced ancient pkgcmd.ctc with pkgcmd.vsct that's buildable with newer VS SDKs
+    - added icons to some commands
+    - search pane did not save its last state, only when switching between file and symbol search
+    - dustmite: pattern passed to "find" must always use quotes

--- a/CHANGES
+++ b/CHANGES
@@ -753,7 +753,7 @@ Version history
   * mago: added support for new AA implementation
   * mago: preview for structs now shows first members
 
-unreleased Version 0.3.43
+2015-11-28 Version 0.3.43
 
   * dustmite: pattern passed to "find" must always use quotes
   * VS2015: new install adds $(VCInstallDir)\bin to exectuable paths to allow cv2pdb to create PDB files
@@ -799,3 +799,5 @@ unreleased Version 0.3.43
     - fix order of identifiers if "#define A B" is converted to an alias
   * additional options: now replacing newline with space when adding to the command line
   * compiling file for syntax check with LDC passed wrong command line option
+  * pass VSINSTALLDIR in the environment to avoid autodetection by LDC
+  * bugzilla 15345: syntax highlighting wrng if asm followed by function attributes

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 #define VERSION_MAJOR      0
 #define VERSION_MINOR      3
 #define VERSION_REVISION   43
-#define VERSION_BETA       -rc
-#define VERSION_BUILD      1
+#define VERSION_BETA       
+#define VERSION_BUILD      0

--- a/doc/StartPage.dd
+++ b/doc/StartPage.dd
@@ -3,8 +3,8 @@ Ddoc
 $(TABLE_NOBORDER
 $(TD $(IMG images/vd_logo.png))
 $(TD
-$(P Visual D is a Visual Studio package providing both project management and language services. 
-It works with Visual Studio 2005 - 2015 including Visual Studio Community 2013/2015 as well as the free Visual Studio Shells. 
+$(P Visual D is a Visual Studio package providing both project management and language services.
+It works with Visual Studio 2005 - 2015 including Visual Studio Community 2013/2015 as well as the free Visual Studio Shells.
 See the $(LINK2 Installation.html, Installation) instructions, especially if not using a commercial edition of Visual Studio.)
 
 $(P Visual D aims at providing seamless integration of the D programming language into Visual Studio.)
@@ -21,7 +21,7 @@ $(H2 Overview)
 $(P Use the navigation bar on the left to take a tour of Visual D including a lot of screen shots.)
 
 $(TABLE_NOBORDER
-$(TD 
+$(TD
 $(UL
  $(LI Project management with all DMD options available through the UI)
  $(LI Syntax highlighting with special version and token string support)
@@ -31,18 +31,19 @@ $(UL
  $(LI Parameter info tooltips)
  $(LI Code outlining)
  $(LI Symbol/File search window)
- $(LI Integration of $(LINK2 https://github.com/rainers/cv2pdb, cv2pdb) and 
+ $(LI Integration of $(LINK2 https://github.com/rainers/cv2pdb, cv2pdb) and
       $(LINK2 http://dsource.org/projects/mago_debugger, Mago) for nice debugging experience)
  $(LI Profiler browse window)
  $(LI Code Coverage support)
  $(LI Support for Error List, Code Definition window, Object Browser and Class View)
  $(LI C++ to D Conversion Wizard)
  $(LI Code completion and tooltips from semantic analysis of source code)
- $(LI Support for building with $(LINK2 https://bitbucket.org/goshawk/gdc/wiki/Home, GDC) 
-      instead of DMD (including 64-bit code))
+ $(LI Support for building with $(LINK2 https://github.com/ldc-developers/ldc, LDC) and
+      $(LINK2 https://github.com/D-Programming-GDC/GDC, GDC)
+      instead of DMD)
  $(LI Completely written in D)
 )
-) $(TD 
+) $(TD
 $(LINK2 images/fullvs.png, <img src="images/fullvs.png" width="100%"/>)
 ))
 
@@ -53,6 +54,13 @@ $(H2 News)
 $(P $(LINK2 VersionHistory.html, Full version history and complete details...)
 )
 
+2015-11-28 Version 0.3.43
+$(UL
+ $(LI improved VS 2015 support)
+ $(LI better support for $(LINK2 https://github.com/ldc-developers/ldc, LDC))
+ $(LI pimped the configuration dialogs)
+)
+
 2015-8-5 Version 0.3.42
 $(UL
  $(LI new command "DustMite Build Failure" to reduce source for build error with $(LINK2 DustMite.html,DustMite))
@@ -61,22 +69,13 @@ $(UL
  $(LI demangling D/C++ symbols in disassembly)
 )
 
-2015-5-16 Version 0.3.41
-$(UL
- $(LI new linker option "build and use local phobos library")
- $(LI dparser updated to with support for new language features in dmd 2.067)
- $(LI mago debugger improvements)
- $(LI new command "$(LINK2 CompileCommands.html,Compile and Disassemble)" to show the disassembly of the current file in
-    the code context window)
-)
-
 $(LINK2 VersionHistory.html, more...)
 
 $(H2 Download)
 
-$(P The latest installer and older versions can be downloaded 
+$(P The latest installer and older versions can be downloaded
 $(LINK2 https://github.com/D-Programming-Language/visuald/releases, here).
-You can find even older versions and some additional files in 
+You can find even older versions and some additional files in
 the $(LINK2 http://www.dsource.org/projects/visuald/browser/downloads/, dsource download directory).)
 
 Macros:

--- a/doc/VersionHistory.dd
+++ b/doc/VersionHistory.dd
@@ -1,5 +1,75 @@
 Ddoc
 
+$(H2 2015-11-28 Version 0.3.43)
+ $(UL
+  $(LI installation
+   $(UL
+    $(LI new install adds $(DOLLAR)(VCInstallDir)\bin to exectuable paths to allow cv2pdb to create PDB files)
+    $(LI moved defaults for resource includes and dmd executable paths from installation to extension init)
+    $(LI tweaked default path and library settings for DMD and LDC)
+  ))
+  $(LI improved VS2015 support
+   $(UL
+    $(LI added detection for Universal CRT in Win10 SDK, new macro replacements $(DOLLAR)(UCRTSdkDir) and
+      $(DOLLAR)(UCRTVersion) allow adding library search path to find libucrt.lib)
+    $(LI fixed spurious "not implemented" error in error list of VS 2015)
+    $(LI fix dark theme detection in VS 2015)
+    $(LI fixed calling linker to build with VC runtime of VS2015: legacy_stdio_definitions.lib missing)
+    $(LI VS2015 linker updates logs and telemetry data files, confusing tracked linker dependencies.
+      Now ignoring files that are both read and written.)
+  ))
+  $(LI project management
+   $(UL
+    $(LI New item: the module name no longer has a preceding '.' when guessing a package name)
+    $(LI renamed command "Add Folder" in project folder context menu to "Add Filter")
+    $(LI added command "Add Folder" to project folder context menu that actually creates the folder on disk)
+    $(LI renaming a module in the project tree now reopens it at the previous caret location)
+    $(LI renaming a package in the project tree also renames the folder on disk if it is still empty)
+    $(LI bugzilla 12021: C++ projects (and others probably, too) might not load correctly in a solution)
+      that also contains a Visual D project
+  ))
+  $(LI build system
+   $(UL
+    $(LI debug info: added option "suitable for selected debug engine")
+    $(LI LDC: recent versions build object files into intermediate folder, wrong names passed to linker
+      with "separate compile and link")
+    $(LI debug option: allow none of -debug and -release to be specified (and fix LDC never to receive
+      the -d-debug option))
+    $(LI additional options: now replacing newline with space when adding to the command line)
+    $(LI compiling file for syntax check with LDC passed wrong command line option)
+    $(LI pass VSINSTALLDIR in the environment to avoid autodetection by LDC)
+  ))
+  $(LI language service
+   $(UL
+    $(LI the original semantic analysis engine is no longer installed, always using dparser now)
+    $(LI better semantic/colorizer support for versions LDC,CRuntime_Microsoft,CRuntime_DigitalMars and MinGW)
+    $(LI bugzilla 15345: syntax highlighting wrong if asm followed by function attributes)
+  ))
+  $(LI configuration dialogs:
+   $(UL
+    $(LI fixed small fonts in VS2015)
+    $(LI better work with resizeable windows)
+    $(LI scale some controls vertically if there is space)
+    $(LI added browse buttons to path settings)
+  ))
+  $(LI some improvements to the C++ to D conversion wizard:
+   $(UL
+    $(LI don't stop conversion after an unmatched } (this also caused other messages to not be displayed))
+    $(LI added support for sizeof without parenthesis)
+    $(LI allow namespace scope in type names)
+    $(LI allow virtual destructors)
+    $(LI skip throw function specification)
+    $(LI fix order of identifiers if "#define A B" is converted to an alias)
+  ))
+  $(LI miscellaneous
+   $(UL
+    $(LI dustmite: pattern passed to "find" must always use quotes)
+    $(LI added icons to some commands)
+    $(LI search pane did not save its last state, only when switching between file and symbol search)
+    $(LI replaced ancient pkgcmd.ctc with pkgcmd.vsct that's buildable with newer VS SDKs)
+  ))
+ )
+
 $(H2 2015-8-5 Version 0.3.42)
  $(UL
   $(LI build system
@@ -35,7 +105,7 @@ $(H2 2015-8-5 Version 0.3.42)
     $(LI case sensitivity button was restored inverted)
   ))
   $(LI installer now shows the version of Visual D about to be installed)
-))
+ )
 
 $(H2 2015-5-16 Version 0.3.41)
  $(UL
@@ -47,7 +117,7 @@ $(H2 2015-5-16 Version 0.3.41)
   ))
   $(LI language service
    $(UL
-    $(LI dparser updated to cf26dbe426b10957f6364313cc7121e41083bebe with support for new 
+    $(LI dparser updated to cf26dbe426b10957f6364313cc7121e41083bebe with support for new
          language features in dmd 2.067 and fixing a number of exceptions)
     $(LI some initial support for finding symbol references)
     $(LI new command "Compile and Disassemble" to show the disassembly of the current file in
@@ -61,7 +131,7 @@ $(H2 2015-5-16 Version 0.3.41)
     $(LI callstack: parameter list also showed locals)
     $(LI disassembly: show symbols, address labels)
     $(LI fix dstring display)
-    $(LI can list associative array members (needs 
+    $(LI can list associative array members (needs
          https://github.com/D-Programming-Language/dmd/pull/4473 for Win64, new AA
          implementation in dmd 2.068 not supported yet, though))
     $(LI show exception number for Win32 exceptions)
@@ -84,7 +154,7 @@ $(H2 2015-1-1 Version 0.3.40)
          $(LI common command line options can be specified on the compiler page of the project)
          $(LI special command line options can be added per file)
          $(LI $(CC) expands to the compiler executable of the current D compiler: dmc, cl, gcc or clang)
-         $(LI if "Translate D options" is checked, dmd options for -g, -release, -O are translated to 
+         $(LI if "Translate D options" is checked, dmd options for -g, -release, -O are translated to
               the respective C/C++ compiler option)
        ))
      $(LI Win32/COFF support: check box on Compiler->Output page, new tab in global options)
@@ -248,7 +318,7 @@ $(H2 2013-11-02 Version 0.3.37)
   $(LI syntax/coverage highlighting
    $(UL
     $(LI editor always started with coverage highlighting enabled)
-    $(LI Colorize coverage: 
+    $(LI Colorize coverage:
      $(UL
       $(LI disabled if lst file older than source file or deleted)
       $(LI tweaked line number translation)
@@ -325,9 +395,9 @@ $(H2 2013-05-10 $(DDLINK News36,Version 0.3.36))
     $(LI added keyword __argTypes)
    )
   )
-  $(LI syntax highlighting and semantic now fully support version identifiers according 
+  $(LI syntax highlighting and semantic now fully support version identifiers according
     to http://dlang.org/version.html )
-  $(LI improved parser/semantics: 
+  $(LI improved parser/semantics:
    $(UL
     $(LI fix "forgetting" type of function parameters after first evaluation)
     $(LI fix a number of crashes during semantics)
@@ -350,7 +420,7 @@ $(H2 2013-05-10 $(DDLINK News36,Version 0.3.36))
   $(LI added command "Open Language Options" for easier access to the settings page)
   $(LI added option "Colorize coverage from .LST file" to highlight lines from code coverage output)
  )
- 
+
 $(H2 2012-12-03 Version 0.3.35)
  $(UL
   $(LI new linker option to disable using global and standard library search paths)
@@ -375,7 +445,7 @@ $(H2 2012-12-03 Version 0.3.35)
   $(LI added console application project template with configurations for DMD and GDC for Win32 and x86)
   $(LI fixed spurious crashes due to bug in precise garbage collection)
  )
- 
+
 $(H2 2012-10-12 Version 0.3.34)
  $(UL
   $(LI fix exceptions in NDepend when opening context menu on D project)
@@ -388,7 +458,7 @@ $(H2 2012-10-12 Version 0.3.34)
   $(LI fix calling cv2pdb for D1)
   $(LI goto definition: if ".." is used to reference the source file path, it could be opened twice in the editor)
   $(LI new item: package and module name now filled with some guess)
-  $(LI optlink now called directly with file monitoring: this allows passing the library path directly (making the DMD_LIB 
+  $(LI optlink now called directly with file monitoring: this allows passing the library path directly (making the DMD_LIB
     patch in sc.ini redundant) and detecting library and source dependencies )
   $(LI parser could not recover from error in module statement, also improved recovery from error in enum declaration)
   $(LI parse errors in modules imported during semantic analysis could cause dramatic troubles)
@@ -414,12 +484,12 @@ $(H2 2012-06-19 Version 0.3.33)
   $(LI debugger project settings now stored in solution options file, not in project file)
   $(LI regression: clean project failed, now deletes files given by wildcard recursively)
   $(LI token replace: fixed freeze when trying to replace no tokens)
-  $(LI cv2pdb: new version 0.25 that allows specifying a different pdb file being embedded 
+  $(LI cv2pdb: new version 0.25 that allows specifying a different pdb file being embedded
     into the binary and supports VS11 )
   $(LI cv2pdb: exposed command line options in the project options)
   $(LI intellisense tool tip now shows enumerator value)
   $(LI moved parser and semantic analysis into another process)
-  $(LI GDC: user specified libraries are now appended after the source files to the command 
+  $(LI GDC: user specified libraries are now appended after the source files to the command
     line to avoid linker problems )
   $(LI improved performance when indenting multiple lines of code)
   $(LI remove project item: now asks whether file on disk should also be removed)
@@ -608,7 +678,7 @@ $(H2 2011-02-27 Version 0.3.22)
   $(LI Visual D now builds with DMD 2.052)
   $(LI fixed WindowsApp template to build with DMD 2.052)
   $(LI fixed some COM leaks)
-  $(LI paste ring menu no longer stops when repeating the first entry and 
+  $(LI paste ring menu no longer stops when repeating the first entry and
     avoids duplicate entries )
   $(LI new token search and replace dialog)
   $(LI new compilation mode: compile and link in separate steps allowing multiple object files)
@@ -627,7 +697,7 @@ $(H2 2011-01-29 Version 0.3.21)
   $(LI brace highlighting now done in idle handling, so it also works when moving
     the caret with the mouse )
   $(LI brace matching now also includes strings and nested comments)
-  $(LI goto matching brace now implemented (the VS implementation does not work 
+  $(LI goto matching brace now implemented (the VS implementation does not work
     well with D) )
   $(LI completion: items are no longer displayed multiple times)
   $(LI improved handling of unicode characters in environment and batch files)
@@ -671,7 +741,7 @@ $(H2 2010-11-07 Version 0.3.18)
   $(LI improved dependency file parsing speed)
   $(LI bugfix: imports with selective import symbols could miss from dependent import files)
   $(LI now packaged with cv2pdb 0.18)
-  $(LI now packaged with new mago version, including better exception handling and 
+  $(LI now packaged with new mago version, including better exception handling and
     disassembly support )
   $(LI fixed mago deinstallation, added mago to Visual Studio About window)
   $(LI added token identifier enumerator to lexer)
@@ -709,7 +779,7 @@ $(H2 2010-09-24 Version 0.3.16)
 
 $(H2 2010-08-11 Version 0.3.15)
  $(UL
-  $(LI when reading import paths from sc.ini, the directory is determined by searching dmd.exe 
+  $(LI when reading import paths from sc.ini, the directory is determined by searching dmd.exe
     through the executable paths setting and the PATH environment variable )
   $(LI fixed freeze when searching indentation level for smart indent (might also affect brace
     matching) )
@@ -755,7 +825,7 @@ $(H2 2010-06-25 Version 0.3.12)
  $(UL
   $(LI stricter string handling to avoid crashes when launching debugger in VS2010)
   $(LI the windows application template's sub-system version now defaults to 4.0)
-  $(LI added new project item template for package creating both folder in project and 
+  $(LI added new project item template for package creating both folder in project and
     directory on disk )
   $(LI if a directory exists with the name of the folder, the default location
     of a new project item now defaults to this directory )
@@ -771,7 +841,7 @@ $(H2 2010-06-10 Version 0.3.11)
   $(LI Visual D settings now stored in the user area of the registry)
   $(LI added library search path to project settings (you need to append ";%LIB%" to
     the LIB setting in DMD's sc.ini for this to work) )
-  $(LI command VisualD.ShowScope now displays the scope of the caret in the 
+  $(LI command VisualD.ShowScope now displays the scope of the caret in the
     status line )
   $(LI Visual D now creates its own menu, expecting to be filled with more commands
     in the future and to avoid cluttering other menus )
@@ -800,7 +870,7 @@ $(H2 2010-05-28 Version 0.3.9)
   $(LI fixed COM leak)
   $(LI fix: file opened through "goto definition"/"find in files" sometimes warns
     "already opened in editor")
-  $(LI fix: "goto error" sometimes would not jump to error with message 
+  $(LI fix: "goto error" sometimes would not jump to error with message
     "cannot find the file specified")
   $(LI fix: last version would not let you select any but the first entry of an
     expansion list)
@@ -868,7 +938,7 @@ $(H2 2010-04-14 Version 0.3.2)
   $(LI added switch "use other compiler" to project settings)
   $(LI disabled settings if respective enable switch is off)
  )
-  
+
 $(H2 2010-04-13 Version 0.3.1)
  $(UL
   $(LI initial release)

--- a/doc/build_doc.bat
+++ b/doc/build_doc.bat
@@ -1,6 +1,6 @@
-set DMD=m:\s\d\rainers\windows\bin\dmd.exe
+set DMD=c:\s\d\rainers\windows\bin\dmd.exe
 rem set WEB=m:\s\d\rainers\web\visuald
-set WEB=m:\s\d\visuald\gh-pages\visuald
+set WEB=c:\s\d\visuald\gh-pages\visuald
 
 set SRC=ReportingBugs.dd
 set SRC=%SRC% StartPage.dd

--- a/doc/visuald.ddoc
+++ b/doc/visuald.ddoc
@@ -1,4 +1,4 @@
-VERSION = 0.3.42
+VERSION = 0.3.43
 ROOT_DIR = http://www.dlang.org/
 ROOT = .
 BODYCLASS = doc

--- a/visuald/colorizer.d
+++ b/visuald/colorizer.d
@@ -1122,13 +1122,13 @@ class Colorizer : DisposingComObject, IVsColorizer, ConfigModifiedListener
 		case VersionParseState.AsmParsedEnabled:
 			if(text == "{")
 				parseState = VersionParseState.InAsmBlockEnabled;
-			else
+			else if (text != "nothrow" && text != "pure" && !text.startsWith("@"))
 				parseState = VersionParseState.IdleEnabled;
 			break;
 		case VersionParseState.AsmParsedDisabled:
 			if(text == "{")
 				parseState = VersionParseState.InAsmBlockDisabled;
-			else
+			else if (text != "nothrow" && text != "pure" && !text.startsWith("@"))
 				parseState = VersionParseState.IdleDisabled;
 			goto case VersionParseState.IdleDisabled;
 

--- a/visuald/config.d
+++ b/visuald/config.d
@@ -2957,6 +2957,8 @@ class Config :	DisposingComObject,
 				cmd ~= "set WindowsSdkDir=" ~ globOpt.WindowsSdkDir ~ "\n";
 			if(globOpt.VCInstallDir.length)
 				cmd ~= "set VCINSTALLDIR=" ~ globOpt.VCInstallDir ~ "\n";
+			if(globOpt.VSInstallDir.length)
+				cmd ~= "set VSINSTALLDIR=" ~ globOpt.VSInstallDir ~ "\n";
 		}
 		return cmd;
 	}


### PR DESCRIPTION
changes from rc 1:
- bugzilla 15345: syntax highlighting wrong if asm followed by function attributes
- pass VSINSTALLDIR in the environment to avoid autodetection by LDC
- updated docs