### PR TITLE
Set `Dversion` to 2 instead of 2.043.

### DIFF
--- a/visuald/config.d
+++ b/visuald/config.d
@@ -268,7 +268,7 @@ class ProjectOptions
 
 	this(bool dbg, bool x64)
 	{
-		Dversion = 2.043;
+		Dversion = 2;
 		exefile = "$(OutDir)\\$(ProjectName).exe";
 		outdir = "$(ConfigurationName)";
 		objdir = "$(OutDir)";


### PR DESCRIPTION
Originally version 2.043 was needed for *cv2pdb*, but commit fac2fdf741f6c9e9605a3010654bec473dfb325d added cv2pdb options to project and removed this version from UI. As a result now UI sets `Dversion` to 2 once `GeneralPropertyPage.DoApply` returns non-zero.