### PR TITLE
Ivan Smirnov's redesign

### DIFF
--- a/doc/build_doc.bat
+++ b/doc/build_doc.bat
@@ -25,7 +25,7 @@ set SRC=%SRC% News36.dd
 set SRC=%SRC% CompileCommands.dd
 set SRC=%SRC% DustMite.dd
 
-set DDOC=macros.ddoc html.ddoc visuald.ddoc dlang.org.ddoc
+set DDOC=macros.ddoc html.ddoc dlang.org.ddoc visuald.ddoc
 
 if not exist %WEB% md %WEB%
 if not exist %WEB%\images md %WEB%\images

--- a/doc/dlang.org.ddoc
+++ b/doc/dlang.org.ddoc
@@ -26,11 +26,11 @@ CODE_RCURL=$(D })
 _=
 
 COMMON_HEADERS_DLANG=
-<link rel="stylesheet" href="$(STATIC css/codemirror.css)" />
+<link rel="stylesheet" href="$(STATIC css/codemirror.css)">
 _=
 COMMON_SCRIPTS =
     $(SCRIPTLOAD https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js)
-    $(SCRIPT window.jQuery || document.write('<script src="$(STATIC js/jquery-1.7.2.min.js)">\x3C/script>');$(EXTRA_JS))
+    $(SCRIPT window.jQuery || document.write('\x3Cscript src="$(STATIC js/jquery-1.7.2.min.js)">\x3C/script>');$(EXTRA_JS))
     $(SCRIPTLOAD $(STATIC js/dlang.js))
     $(COMMON_SCRIPTS_DLANG)
 _=
@@ -59,39 +59,39 @@ DDOC=
     http://digitalmars.com
   -->
 <head>
-<meta charset="utf-8" />
-<meta name="keywords" content="$(META_KEYWORDS)" />
-<meta name="description" content="$(META_DESCRIPTION)" />
+<meta charset="utf-8">
+<meta name="keywords" content="$(META_KEYWORDS)">
+<meta name="description" content="$(META_DESCRIPTION)">
 $(T title, $(FULL_TITLE))
 $(COMMON_HEADERS_DLANG)
-<link rel="stylesheet" href="$(STATIC css/style.css)" />
-<link rel="stylesheet" href="$(STATIC css/print.css)" media="print" />
-<link rel="stylesheet" href="$(STATIC css/cssmenu.css)">
-<link rel="shortcut icon" href="$(FAVICON)" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.1, maximum-scale=10.0" />
+<link rel="stylesheet" href="$(STATIC css/style.css)">
+<link rel="stylesheet" href="$(STATIC css/print.css)" media="print">
+<link rel="shortcut icon" href="$(FAVICON)">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.1, maximum-scale=10.0">
 $(EXTRA_HEADERS)
 </head>
 <body id='$(TITLE)' class='$(BODYCLASS)'>
 $(SCRIPT document.body.className += ' have-javascript')
-$(DIVID top,
-	$(DIVID header,
-		<img src="$(STATIC images/hamburger.svg)" id="mobile-hamburger">
-		<a class="logo" href="$(ROOT_DIR)"><img id="logo" width="125" height="95" alt="D Logo" src="$(STATIC images/dlogo.svg)"></a>
-		<span id="d-language-mobilehelper"><a href="$(ROOT)" id="d-language">D Programming Language</a></span>
-	)
-)
-$(DIVID navigation,
-    $(SEARCH_BOX)
+$(DIVID top, $(DIVC helper, $(DIVC helper expand-container,
+    $(DIVC logo, <a href="$(ROOT)"><img id="logo" alt="D Logo" src="$(STATIC images/dlogo.svg)"></a>)
+    <a href="$(ROOT_DIR)menu.html" title="Menu" class="hamburger expand-toggle"><span>Menu</span></a>
     $(NAVIGATION)
-)
+    $(DIVC search-container expand-container,
+        <a href="$(ROOT_DIR)search.html" class="expand-toggle" title="Search"><span>Search</span></a>
+        $(SEARCH_BOX)
+    )
+)))
 $(LAYOUT_PREFIX)
-$(DIVCID $(HYPHENATE), content,
-    $(PAGE_TOOLS)
-    $(LAYOUT_TITLE)
-    $(BODY_PREFIX)
-    $(BODY)
+$(DIVC container,
+    $(SUBNAV)
+    $(DIVCID $(HYPHENATE), content,
+        $(PAGE_TOOLS)
+        $(LAYOUT_TITLE)
+        $(BODY_PREFIX)
+        $(BODY)
+        $(FOOTER)
+    )
 )
-$(FOOTER)
 $(COMMON_SCRIPTS)
 $(LAYOUT_SUFFIX)
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
@@ -99,7 +99,7 @@ $(LAYOUT_SUFFIX)
 </html>
 _=
 
-DDLINK=$(LINK2 $1.html, $3)
+DDLINK=$(LINK2 $(ROOT_DIR)$1.html, $3)
 DDOC_BACKQUOTED = $(D $0)
 DDOC_SUMMARY   = $(DIVC summary, $0)
 DDOC_DESCRIPTION = $(DIVC description, $0)
@@ -117,27 +117,29 @@ DDOC_STANDARDS = $(DDOCKEYVAL Standards, $0)
 DDOC_THROWS    = $(DDOCKEYVAL Throws, $0)
 DDOC_VERSION   = $(DDOCKEYVAL Version, $0)
 DDOC_SECTION_H = <p class="keyval Section">$(SPANC key keySection, $0)
-DDOC_SECTION   = $(DIVC val, $0)
+DDOC_SECTION   = $(DIVC val, $0</p>)
 DDOC_PARAM_ROW = <tr class="param">$0</tr>
 DDOC_PARAM_ID  = <td class="param_id">$0</td>
 DDOC_PARAM_DESC  = <td class="param_desc">$0</td>
-DDOC_PARAMS    = $(DDOCKEYVAL Parameters, <table class=params>$0</table>)
+DDOC_PARAMS    = $(DDOCKEYVAL Parameters, <table class="params">$0</table>)
 DDOC_BLANKLINE	= $(P)
 DDOC_PSYMBOL = $(ADEF $0)$(SPANC ddoc_psymbol, $0)
 DDOC_ANCHOR = $(ADEF .$1)$(DIVCID quickindex, quickindex.$1, )
-DDOC_DECL  = $(TC dt, d_decl, $0)
+DDOC_DECL  = $(TC dt, d_decl, $(DIV, $0))
 DDOC_UNDEFINED_MACRO = $(DDOC_COMMENT UNDEFINED MACRO: "$1")
 DDOCCODE=$(TC pre, ddoccode notranslate, $0)
 DDOCKEYVAL=$(DIVC keyval $1, $(SPANC key key$1, $1:) $(DIVC val val$1, $+))
 DDOCKEYVAL2=$(DIVC keyval $1, $(SPANC key key$1, $2:) $(DIVC val val$1, $(TAIL $+)))
-DDSUBLINK=$(LINK2 $1.html#$2, $3)
+DDSUBLINK=$(LINK2 $(ROOT_DIR)$1.html#$2, $3)
 _=
 
+DOT_PREFIXED=.$1$(DOT_PREFIXED $+)
+DOT_PREFIXED_SKIP=$(DOT_PREFIXED $+)
 DRUNTIMESRC=$(HTTPS github.com/D-Programming-Language/druntime/blob/master/src/$0, $0)
 DPLLINK=$(LINK2 $1,$+)
 _=
 
-ELABORATE_HEADER=$(TR <th rowspan=2>D</th><th colspan=2>C</th>)
+ELABORATE_HEADER=$(TR <th rowspan="2">D</th><th colspan="2">C</th>)
 $(TR <th scope="col">32 bit</th><th scope="col">64 bit</th>)
 _=
 EXTRA_HEADERS=
@@ -145,7 +147,8 @@ EXTRA_JS=
 _=
 
 FAVICON=$(STATIC favicon.ico)
-FOOTER = $(DIV id="copyright", $(COPYRIGHT) | Page generated by $(WEB dlang.org/ddoc.html, Ddoc) on $(GEN_DATETIME))
+FOOTER = $(DIVCID smallprint, copyright, $(COPYRIGHT) | Page generated by
+$(LINK2 $(ROOT_DIR)spec/ddoc.html, Ddoc) on $(GEN_DATETIME))
 FOOTNOTE=$(SPANC footnote, $0)
 FULL_TITLE=$(TITLE) - D Programming Language
 FULL_XREF=$(XREF $1, $2)
@@ -153,8 +156,9 @@ _=
 
 GEN_DATETIME=$(DATETIME)
 GLINK=$(RELATIVE_LINK2 $0, $(I $0))
-GLINK2=$(DDSUBLINK $1,$2,$(I $2))
+GLINK2=$(DDSUBLINK spec/$1,$2,$(I $2))
 GLOSSARY = $(WEB dlang.org/glossary.html#$0, $0)
+GLOSSARY2 = $(WEB dlang.org/glossary.html#$1, $2)
 GNAME=<a id="$0">$(SPANC gname, $0)</a>
 GRAMMAR=$(TC pre, bnf notranslate, $0)
 GREEN=$(SPANC green, $0)
@@ -163,6 +167,7 @@ _=
 
 HASH=#
 HTMLTAG3=<$1 $2>$(TAIL $+)</$1>
+HTMLTAG3V=<$1 $2>$(TAIL $+)
 HYPHENATE=hyphenate
 _=
 
@@ -173,6 +178,7 @@ LAYOUT_PREFIX=
 LAYOUT_SUFFIX=
 LAYOUT_TITLE=$(H1 $(TITLE))
 LEGACY_LNAME2=<span id="$1">$(LNAME2 $+)</span>
+PHOBOS_PATH=$(ROOT_DIR)phobos/
 LIST=$(UL $(LIX $1, $+))
 LIX=$(LI $1)$(LIX $+)
 LNAME2=<a class="anchor" title="Permalink to this section" id="$1" href="#$1">$+</a>
@@ -187,17 +193,68 @@ _=
 MDASH=$(T nobr, &#x200A;&mdash;&#x200A;)
 METACODE=$(SPANC metacode, $0)
 MENU = <li><a href='$1'><span>$+</span></a></li>
-MENU_W_SUBMENU = <li class='has-sub'><a href='#'><span>$0</span></a>
+MENU_W_SUBMENU = <li class='expand-container'><a class='expand-toggle' href='#'><span>$0</span></a>
+MENU_W_SUBMENU_LINK = <li class='expand-container'><a class='expand-toggle' href='$1'><span>$+</span></a>
+MENU_W_SUBMENU_END = </li>
 META_KEYWORDS=D programming language
 META_DESCRIPTION=D Programming Language
 MODDEFFILE=$(TC pre, moddeffile notranslate, $0)
-MULTICOL_CELL=<td colspan=$1>$+</td>
-MULTICOL_HEADER=<th colspan=$1>$+</th>
+MULTICOL_CELL=<td colspan="$1">$+</td>
+MULTICOL_HEADER=<th colspan="$1">$+</th>
 MULTICOLS=$+
-MULTIROW_HEADER=<th rowspan=$1>$+</th>
+MULTIROW_HEADER=<th rowspan="$1">$+</th>
+MREF=<a href="$(PHOBOS_PATH)$1$(UNDERSCORE_PREFIXED $+).html">$1$(DOT_PREFIXED $+)</a>
 _=
 
-NEWS=http://digitalmars.com/webnews/newsgroups.php?search_txt=&group=$1&article_id=$+
+
+NAVIGATION=
+$(DIVID cssmenu, $(UL
+    $(MENU $(ROOT_DIR)getstarted.html, Learn)
+    $(MENU_W_SUBMENU_LINK $(ROOT_DIR)documentation.html, Documentation)
+      $(NAVIGATION_DOCUMENTATION)
+    $(MENU $(ROOT_DIR)download.html, Downloads)
+    $(MENU http://code.dlang.org, Packages)
+    $(MENU_W_SUBMENU_LINK $(ROOT_DIR)community.html, Community)
+      $(NAVIGATION_COMMUNITY)
+    $(MENU_W_SUBMENU_LINK $(ROOT_DIR)resources.html, Resources)
+      $(NAVIGATION_RESOURCES)
+))
+NAVIGATION_COMMUNITY=
+$(SUBMENU
+    $(ROOT_DIR)bugstats.php, Bug Tracker,
+    http://forum.dlang.org, Forums,
+    irc://irc.freenode.net/d, IRC,
+    http://github.com/D-Programming-Language, D on GitHub,
+    http://wiki.dlang.org, Wiki,
+    http://wiki.dlang.org/Review_Queue, Review Queue,
+    http://twitter.com/search?q=%23dlang, Twitter,
+    http://digitalmars.com/d/dlinks.html, More Links
+)
+NAVIGATION_DOCUMENTATION=
+$(SUBMENU
+    $(ROOT_DIR)spec/intro.html, Language Reference,
+    $(ROOT_DIR)phobos/index.html, Library Reference,
+    $(ROOT_DIR)comparison.html, Feature Overview,
+    $(ROOT_DIR)dmd-windows.html, DMD Manual,
+    $(ROOT_DIR)articles.html, Articles
+)
+NAVIGATION_RESOURCES=
+$(SUBMENU
+    $(ROOT_DIR)library/index.html, NEW Library Reference Preview,
+    $(ROOT_DIR)tools.html, D-Specific Tools,
+    $(VISUALD), Visual D,
+    http://wiki.dlang.org/Editors, Editors,
+    http://wiki.dlang.org/IDEs, IDEs,
+    http://wiki.dlang.org/Tutorials, Tutorials,
+    http://wiki.dlang.org/Books, Books,
+    $(ROOT_DIR)dstyle.html, The D Style,
+    $(ROOT_DIR)glossary.html, Glossary,
+    $(ROOT_DIR)acknowledgements.html, Acknowledgments,
+    $(ROOT_DIR)sitemap.html, Sitemap
+)
+_=
+
+NEWS=http://digitalmars.com/webnews/newsgroups.php?search_txt=$(AMP)group=$1$(AMP)article_id=$+
 NG_digitalmars_D = <a href="$(NEWS digitalmars.D,$0)">D/$0</a>
 NG_digitalmars_D_announce = <a href="$(NEWS digitalmars.D.announce,$0)">D.announce/$0</a>
 NOTRANSLATE=$(SPANC notranslate, $0)
@@ -211,23 +268,23 @@ OPT=$(SUBSCRIPT opt)
 _=
 
 PAGE_TOOLS=
-$(DIVID tools,
-	$(SPANC tip,
-		$(HTMLTAG3 a, href="https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/$(SELF_PATH)&bug_severity=enhancement&component=$(PROJECT)&op_sys=All&priority=P3&product=D&rep_platform=All&short_desc=%5B$(TITLE)%5D&version=D2" class="button", Report a bug)
-		$(SPAN,
+$(DIVID tools, $(DIV,
+	$(DIVC tip smallprint,
+		$(HTMLTAG3 a, href="https://issues.dlang.org/enter_bug.cgi?bug_file_loc=http%3A%2F%2Fdlang.org/$(SELF_PATH)$(AMP)bug_severity=enhancement$(AMP)component=$(PROJECT)$(AMP)op_sys=All$(AMP)priority=P3$(AMP)product=D$(AMP)rep_platform=All$(AMP)short_desc=%5B$(TITLE)%5D$(AMP)version=D2", Report a bug)
+		$(DIV,
 			If you spot a problem with this page, click here to create a Bugzilla issue.
 		)
 	)
-	$(SPANC tip,
-		<a href="https://github.com/D-Programming-Language/$(PROJECT)/edit/master/$(SRCFILENAME)" class="button">Improve this page</a>
-		$(SPAN,
+	$(DIVC tip smallprint,
+		<a href="https://github.com/D-Programming-Language/$(PROJECT)/edit/master/$(SRCFILENAME)">Improve this page</a>
+		$(DIV,
 			Quickly fork, edit online, and submit a pull request for this page.
 			Requires a signed-in GitHub account. This works well for small changes.
 			If you'd like to make larger changes you may want to consider using
-			local clone.
+			a local clone.
 		)
 	)
-)
+))
 _=
 
 PC=$(TC p, $1, $+)
@@ -238,6 +295,8 @@ PHOBOSSRC=$(SPANC phobos_src, $(AHTTPS github.com/D-Programming-Language/phobos/
 _=
 
 RED=$(SPANC red, $0)
+REF=<a href="$(PHOBOS_PATH)$2$(UNDERSCORE_PREFIXED_SKIP $+).html#$1">$(D $2$(DOT_PREFIXED_SKIP $+, $1))</a>
+REF_ALTTEXT=<a href="$(PHOBOS_PATH)$3$(UNDERSCORE_PREFIXED_SKIP2 $+).html#$2">$1</a>
 RELATIVE_LINK2=$(ALOCAL $1, $+)
 _=
 
@@ -246,20 +305,24 @@ SCINI=$(TC pre, scini notranslate, $0)
 SCRIPTLOAD=<script type="text/javascript" src="$0"></script>
 SEARCHDEFAULT_PHOBOS=
 SEARCHDEFAULT_FORUM=
+SEARCHDEFAULT_SPEC=
 SEARCH_BOX=
     $(DIVID search-box,
         <form method="get" action="http://google.com/search">
-            <input type="hidden" id="domains" name="domains" value="dlang.org" />
-            <input type="hidden" id="sourceid" name="sourceid" value="google-search" />
-            $(SPANID search-query, <input id="q" name="q" placeholder="Search" tabindex="1000" />)$(SPANID search-dropdown,
+            <input type="hidden" id="domains" name="domains" value="dlang.org">
+            <input type="hidden" id="sourceid" name="sourceid" value="google-search">
+            $(SPANID search-query, <input id="q" name="q" placeholder="Search">)$(SPANID search-dropdown, $(SPANC helper,
                 <select id="sitesearch" name="sitesearch" size="1">
-                    <option value="dlang.org">Entire D Site</option>
-                    <option $(SEARCHDEFAULT_PHOBOS) value="dlang.org/phobos">Library Reference</option>
-                    <option $(SEARCHDEFAULT_FORUM) value="forum.dlang.org">Discussion Forums</option>
+                    <option value="dlang.org">Entire Site</option>
+                    <option $(SEARCHDEFAULT_SPEC) value="dlang.org/spec">Language</option>
+                    <option $(SEARCHDEFAULT_PHOBOS) value="dlang.org/phobos">Library</option>
+                    <option $(SEARCHDEFAULT_FORUM) value="forum.dlang.org">Forums</option>
+                    $(SEARCH_OPTIONS_EXTRA)
                 </select>
-            )$(SPANID search-submit, <button type="submit"><i class="fa fa-search"></i><span>go</span></button>)
+            ))$(SPANID search-submit, <button type="submit"><i class="fa fa-search"></i><span>go</span></button>)
         </form>
     )
+SEARCH_OPTIONS_EXTRA=
 _=
 
 SECTION1=$(H1 $1)$+
@@ -267,10 +330,62 @@ SECTION2=$(H2 $1)$+
 SECTION3=$(H3 $1)$+
 SECTION4=$(H4 $1)$+
 SECTION5=$(H5 $1)$+
+SLASH_PREFIXED=/$1$(SLASH_PREFIXED $+)
 STATIC=$(ROOT_DIR)$1
-SUBMENU=<ul>$(SUBMENU2 $1,$+)</ul>
+SUBMENU=<ul class='expand-content'>$(SUBMENU2 $1,$+)</ul></li>
 SUBMENU2=<li><a href='$1'>$2</a></li>$(SUBMENU3 $+)
 SUBMENU3=$(SUBMENU2 $+)
+_=
+
+SUBNAV=
+SUBNAV_ARTICLES=
+$(SUBNAV_TEMPLATE
+    $(SUBNAV_HEAD Articles, $(ROOT_DIR)articles.html, overview)
+    $(UL $(SUBMENU2
+        $(ROOT_DIR)faq.html, FAQ,
+        $(ROOT_DIR)const-faq.html, const(FAQ),
+        $(ROOT_DIR)d-floating-point.html, Floating Point,
+        $(ROOT_DIR)warnings.html, Warnings,
+        $(ROOT_DIR)rationale.html, Rationale,
+        $(ROOT_DIR)builtin.html, Builtin Rationale,
+        $(ROOT_DIR)ctod.html, C to D,
+        $(ROOT_DIR)cpptod.html, C++ to D,
+        $(ROOT_DIR)pretod.html, C Preprocessor vs D,
+        $(ROOT_DIR)code_coverage.html, Code coverage analysis,
+        $(ROOT_DIR)exception-safe.html, Exception Safety,
+        $(ROOT_DIR)hijack.html, Hijacking,
+        $(ROOT_DIR)intro-to-datetime.html, Introduction to std.datetime,
+        $(ROOT_DIR)lazy-evaluation.html, Lazy Evaluation,
+        $(ROOT_DIR)migrate-to-shared.html, Migrating to Shared,
+        $(ROOT_DIR)mixin.html, Mixins,
+        $(ROOT_DIR)regular-expression.html, Regular Expressions,
+        $(ROOT_DIR)safed.html, SafeD,
+        $(ROOT_DIR)templates-revisited.html, Templates Revisited,
+        $(ROOT_DIR)ctarguments.html, Compile-time Argument Lists,
+        $(ROOT_DIR)variadic-function-templates.html, Variadic Templates,
+        $(ROOT_DIR)d-array-article.html, D Slices
+    ))
+)
+
+SUBNAV_HEAD=
+    $(DIVC head,
+        $(H2 $1)
+        $(TC p, $4,
+            $(LINK2 $2, $3))
+    )
+SUBNAV_TEMPLATE=$(DIVC subnav-helper) $(DIVC subnav, $0)
+_=
+
+SUBNAV_TOOLS=
+$(SUBNAV_TEMPLATE
+    $(SUBNAV_HEAD D-Specific Tools, $(ROOT_DIR)tools.html, overview)
+    $(UL $(SUBMENU2
+        https://github.com/Hackerpilot/dfix, dfix,
+        https://github.com/Hackerpilot/dfmt, dfmt,
+        $(ROOT_DIR)rdmd.html, rdmd,
+        $(ROOT_DIR)htod.html, htod
+    ))
+)
 _=
 
 TABLE_10=$(TABLE2 $1,$+)
@@ -287,13 +402,17 @@ TOC_LISTING=$0
 TR2=$(TR $1 $2)
 TR3=$(TR $1 $2 $3)
 TROW=$(TR $(TDX $1, $+))
-TROW_EXPLANATORY=<td colspan=10>$0</td>
+TROW_EXPLANATORY=<td colspan="10">$0</td>
 _=
 
 UNDERSCORE=_
+UNDERSCORE_PREFIXED=_$1$(UNDERSCORE_PREFIXED $+)
+UNDERSCORE_PREFIXED_SKIP=$(UNDERSCORE_PREFIXED $+)
+UNDERSCORE_PREFIXED_SKIP2=$(UNDERSCORE_PREFIXED_SKIP $+)
 _=
 
 VERTROW=$(TR $(TDX $1, $+))
+VISUALD = http://rainers.github.io/visuald/visuald/StartPage.html
 _=
 
 WHITE=$(SPANC white, $0)

--- a/doc/html.ddoc
+++ b/doc/html.ddoc
@@ -46,7 +46,7 @@ SPANID = $(SPAN id="$1", $+)
 SUBSCRIPT = $(T sub, $0)
 SUPERSCRIPT = $(T sup, $0)
 TABLE = $(T table, $0)
-TABLEC = $(T table, $1, $+)
+TABLEC = $(TC table, $1, $+)
 T=<$1>$+</$1>
 TC=<$1 class="$2">$(TAIL $+)</$1>
 TD = $(T td, $0)
@@ -101,7 +101,7 @@ _=Main entry point
 DDOC = $(T html,
 $(T head,
   <META http-equiv="content-type" content="text/html; charset=utf-8">
-  <link rel="stylesheet" type="text/css" href="css/html.css" />
+  <link rel="stylesheet" type="text/css" href="css/html.css">
   $(T title, $(TITLE))
 )
 $(T body, $(H1 $(TITLE))$(BODY)))
@@ -162,6 +162,9 @@ DDOC_ANCHOR  = $(ADEF $1)
 DDOC_PSYMBOL = $(U $0)
 DDOC_KEYWORD = $(B $0)
 DDOC_PARAM   = $(I $0)
+DDOC_OVERLOAD_SEPARATOR = $(BR)
+DDOC_CONSTRAINT=$(BR)$(SPAN class="constraint", if ($0))
+DDOC_TEMPLATE_PARAM_LIST=$(SPAN class="template_param_list" title="Template parameter list", $0)
 _=
 
 _=Generic blurb to describe C header bindings

--- a/doc/macros.ddoc
+++ b/doc/macros.ddoc
@@ -2,7 +2,7 @@ _=Fundamental macros that apply to all generated formats
 
 ARGS = $0
 COMMA = ,
-COMMENT = 
+COMMENT =
 DOLLAR = $
 LPAREN = (
 RPAREN = )

--- a/doc/visuald.ddoc
+++ b/doc/visuald.ddoc
@@ -1,8 +1,7 @@
 VERSION = 0.3.43
 ROOT_DIR = http://www.dlang.org/
-ROOT = .
-BODYCLASS = doc
-SEARCHDEFAULT_PHOBOS =
+ROOT = http://www.dlang.org
+BODYCLASS = visuald
 PROJECT = visuald
 WIKI = visuald
 SELF_PATH =
@@ -14,53 +13,34 @@ IMG_CENTER = <div align="center"><img src="$0" /></div>
 TABLE_NOBORDER = <table style="border-width: 0px 0">$0</table>
 _=
 
-NAVIGATION=
-$(DIVID cssmenu, $(UL
-    $(MENU StartPage.html, Visual D $(VERSION))
-    $(MENU https://github.com/D-Programming-Language/visuald/releases, Downloads)
-    $(MENU Installation.html, Installation)
-    $(MENU_W_SUBMENU Documentation)
-      $(SUBMENU 
-        Features.html, Features,
-        GlobalOptions.html, Global options,
-        ProjectWizard.html, Project Wizard,
-        Editor.html, Editor,
-        Search.html, Search Window,
-        TokenReplace.html, Token Replace,
-        ProjectConfig.html, Project Config,
-        CppConversion.html, C++ to D,
-        Debugging.html, Debugging,
-        CompileCommands.html, Compile Commands,
-        Profiling.html, Profiling,
-        Coverage.html, Code Coverage,
-        DustMite.html, DustMite,
-        BrowseInfo.html, Browse Info
-      )
-    $(MENU VersionHistory.html, Version History)
-    $(MENU KnownIssues.html, Known Issues)
-    $(MENU BuildFromSource.html, Building from Source)
-
-    $(MENU_W_SUBMENU Resources)
-      $(SUBMENU
-        $(ROOT_DIR)intro.html, Language Reference,
-        $(ROOT_DIR)phobos/index.html, Library Reference,
-        http://code.dlang.org, D Libraries,
-        $(ROOT_DIR)bugstats.php, Bug Tracker,
-        $(ROOT_DIR)faq.html, FAQ,
-        $(ROOT_DIR)dstyle.html, The D Style,
-        http://arsdnet.net/this-week-in-d, This Week in D
-      )
-    $(MENU_W_SUBMENU Community)
-      $(SUBMENU
-        http://forum.dlang.org, Forums,
-        irc://irc.freenode.net/d, IRC,
-        http://github.com/D-Programming-Language, D on GitHub,
-        http://wiki.dlang.org, Wiki,
-        http://wiki.dlang.org/Review_Queue, Review Queue,
-        http://twitter.com/search?q=%23dlang, Twitter,
-        http://digitalmars.com/d/dlinks.html, More Links
-      )
-))
+SUBNAV=$(SUBNAV_TEMPLATE
+    $(SUBNAV_HEAD Visual D $(VERSION), StartPage.html, Home, subnav-duplicate)
+    $(UL
+        $(MENU StartPage.html, Home)
+        $(MENU https://github.com/D-Programming-Language/visuald/releases, Downloads)
+        $(MENU Installation.html, Installation)
+        $(MENU_W_SUBMENU Documentation)
+        $(SUBMENU
+            Features.html, Features,
+            GlobalOptions.html, Global options,
+            ProjectWizard.html, Project Wizard,
+            Editor.html, Editor,
+            Search.html, Search Window,
+            TokenReplace.html, Token Replace,
+            ProjectConfig.html, Project Config,
+            CppConversion.html, C++ to D,
+            Debugging.html, Debugging,
+            CompileCommands.html, Compile Commands,
+            Profiling.html, Profiling,
+            Coverage.html, Code Coverage,
+            DustMite.html, DustMite,
+            BrowseInfo.html, Browse Info
+        )
+        $(MENU VersionHistory.html, Version History)
+        $(MENU KnownIssues.html, Known Issues)
+        $(MENU BuildFromSource.html, Building from Source)
+    )
+)
 _=
 
 D_S      = $(LAYOUT ,$1,$(ARGS $+))


### PR DESCRIPTION
(Second try after mistakenly making a PR to Rainer's fork first.)

Depends on and complements the main site PR: D-Programming-Language/dlang.org#1190. Do not put online before the main site redesign has gone online. Also, maybe wait with pulling until the main site PR has been pulled, so that I can update the files here when they change there.

I've simply overwritten macros.ddoc, html.ddoc, and dlang.org.ddoc with the new versions. The visuald versions had changes to make them XHTML. If that's needed, I suggest to get the changes into the dlang.org repo, so that the visuald copies can be plain copies.

Screenshot:
![Screenshot](https://cloud.githubusercontent.com/assets/9287500/12333804/9b5c96a6-baf6-11e5-9a14-5ba63f57873b.png)